### PR TITLE
Clear the cache on preference changes

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -33,7 +33,7 @@ object SbtScalariformBuild extends Build {
     settings = Defaults.defaultSettings ++ SbtScalariform.scalariformSettings ++ Seq(
       organization := "org.scalariform",
       name := "sbt-scalariform",
-      version in ThisBuild := "1.4.0",
+      version in ThisBuild := "1.5.0",
       resolvers ++= Resolvers.resolvers,
       libraryDependencies ++= Dependencies.sbtScalariform,
       scalacOptions ++= List(

--- a/src/main/scala/com/typesafe/sbt/PreferencesProtocol.scala
+++ b/src/main/scala/com/typesafe/sbt/PreferencesProtocol.scala
@@ -1,0 +1,24 @@
+package com.typesafe.sbt
+
+import java.io.{ StringReader, StringWriter }
+import java.util.Properties
+import sbinary.Operations._
+import sbinary.{ Input, Output, Format, DefaultProtocol }
+import scalariform.formatter.preferences.{ PreferencesImporterExporter, IFormattingPreferences }
+
+object PreferencesProtocol extends DefaultProtocol {
+
+  implicit object PrefFormat extends Format[IFormattingPreferences]() {
+    override def writes(out: Output, value: IFormattingPreferences): Unit = {
+      val outStream = new StringWriter()
+      PreferencesImporterExporter.asProperties(value).store(outStream, null)
+      write[String](out, outStream.toString)
+    }
+
+    override def reads(in: Input): IFormattingPreferences = {
+      val properties = new Properties
+      properties.load(new StringReader(read[String](in)))
+      PreferencesImporterExporter.getPreferences(properties)
+    }
+  }
+}


### PR DESCRIPTION
Hey @daniel-trinh,

Previously, if you change the preferences you are using, the plugin will only re-run scalariform on source files if they are considered dirty. This change makes it so that any changes to preferences clears this cache, so that subsequent runs of scalariform will be run on all files.

I was thinking this lines up better with what users would expect, as if a user decides to change the preferences, they will probably want to re-run scalariform on all their source files right?

Let me know what you think. 
