### PR TITLE
Add integration test support from sbt/sbt-scalariform

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ ScalariformKeys.preferences := ScalariformKeys.preferences.value
 
 If you don't want sbt to automatically format your source files when the tasks `compile` or `test:compile`, just add `defaultScalariformSettings` instead of `scalariformSettings` to your build definition.
 
+If you want to additionally enable Scalariform for your integration tests, use `scalariformSettingsWithIt` or `defaultScalariformSettingsWithIt` instead of the above.
+
 Other useful configuration options are provided by common sbt setting keys:
 
 - `includeFilter in format`: Defaults to **.scala*

--- a/src/main/scala/com/typesafe/sbt/SbtScalariform.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtScalariform.scala
@@ -17,9 +17,10 @@
 package com.typesafe.sbt
 
 import sbt._
+import sbt.{ IntegrationTest => It }
 import sbt.Keys._
 import scala.collection.immutable.Seq
-import scalariform.formatter.preferences.{ FormattingPreferences, IFormattingPreferences }
+import scalariform.formatter.preferences.IFormattingPreferences
 
 object SbtScalariform extends Plugin {
 
@@ -54,8 +55,18 @@ object SbtScalariform extends Plugin {
       compileInputs in (Test, compile) <<= (compileInputs in (Test, compile)) dependsOn (format in Test)
     )
 
+  def scalariformSettingsWithIt: Seq[Setting[_]] =
+    defaultScalariformSettingsWithIt ++ List(
+      compileInputs in (Compile, compile) <<= (compileInputs in (Compile, compile)) dependsOn (format in Compile),
+      compileInputs in (Test, compile) <<= (compileInputs in (Test, compile)) dependsOn (format in Test),
+      compileInputs in (It, compile) <<= (compileInputs in (It, compile)) dependsOn (format in It)
+    )
+
   def defaultScalariformSettings: Seq[Setting[_]] =
     noConfigScalariformSettings ++ inConfig(Compile)(configScalariformSettings) ++ inConfig(Test)(configScalariformSettings)
+
+  def defaultScalariformSettingsWithIt: Seq[Setting[_]] =
+    defaultScalariformSettings ++ inConfig(It)(configScalariformSettings)
 
   def configScalariformSettings: Seq[Setting[_]] =
     List(


### PR DESCRIPTION
This PR copies the integration test support that was added in [sbt/sbt-scalariform](https://github.com/sbt/sbt-scalariform). 

Aside from sbt settings (different build definition) this is the only relevant change from the upstream repository.
