### PR TITLE
Update advanced config docs to be consistent with advertised version (1.5.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Advanced configuration
 ----------------------
 sbt-scalariform comes with various configuration options. Changing the formatting preferences and deactivating the automatic formatting on compile are probably the most important ones and described in detail.
 
-You can provide your own formatting preferences for Scalariform via the setting key `ScalariformKeys.preferences` which expects an instance of `IFormattingPreferences`. Make sure you import all necessary members from the package `scalariform.formatter.preferences`. Let's look at an example:
+You can provide your own formatting preferences for Scalariform via the setting key `scalariformPreferences`. Make sure you import all necessary members from the package `scalariform.formatter.preferences`. Let's look at an example:
 
 .sbt build example
 ```
@@ -87,6 +87,7 @@ import com.typesafe.sbt.SbtScalariform
 SbtScalariform.scalariformSettings
 
 ScalariformKeys.preferences := ScalariformKeys.preferences.value
+#scalariformPreferences := scalariformPreferences.value
   .setPreference(AlignSingleLineCaseStatements, true)
   .setPreference(DoubleIndentClassDeclaration, true)
   .setPreference(PreserveDanglingCloseParenthesis, true)


### PR DESCRIPTION
Based on https://github.com/daniel-trinh/sbt-scalariform/issues/16, this should help new users (or those migrating to 1.5.1) with using advanced configuration.
