### PR TITLE
Format files in all source directories

### DIFF
--- a/src/main/scala/com/typesafe/sbt/SbtScalariform.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtScalariform.scala
@@ -84,7 +84,7 @@ object SbtScalariform extends AutoPlugin {
 
   def configScalariformSettings: Seq[Setting[_]] =
     List(
-      (sourceDirectories in scalariformFormat) := List(scalaSource.value),
+      (sourceDirectories in scalariformFormat) := sourceDirectories,
       scalariformFormat := Scalariform(
         scalariformPreferences.value,
         (sourceDirectories in scalariformFormat).value.toList,


### PR DESCRIPTION
`scalaSource` only works for basic projects. Other projects may have defined more elaborate source directory setups e.g. in any kind of cross-building scheme where sources per version are lying in different directories.

Alternatively, it may make sense to restrict this to `unmanagedSourceDirectories` to prevent that auto-generated files are run through the formatter (though, you might want this as well).
