### PR TITLE
Fix imports for Advanced Configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,7 @@ You can provide your own formatting preferences for Scalariform via the setting 
 .sbt build example
 ```
 import scalariform.formatter.preferences._
-import com.typesafe.sbt.SbtScalariform
-
-SbtScalariform.scalariformSettings
+import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 
 ScalariformKeys.preferences := ScalariformKeys.preferences.value
   .setPreference(AlignSingleLineCaseStatements, true)
@@ -96,6 +94,7 @@ ScalariformKeys.preferences := ScalariformKeys.preferences.value
 ```
 import scalariform.formatter.preferences._
 import com.typesafe.sbt.SbtScalariform
+import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 
 lazy val project = Project(
     ...


### PR DESCRIPTION
I noticed, while setting up a new project to use Scalariform, that the advanced configuration as described in the readme, for SBT, doesn't work. I've updated the readme to reflect the changes I made to make it work. I've also updated the Scala version while I was at it.
